### PR TITLE
fault: ignore when lines are moved within or between files

### DIFF
--- a/git-fault
+++ b/git-fault
@@ -7,4 +7,4 @@
 NUM_TO_DISPLAY=4
 
 # http://www.commandlinefu.com/commands/view/3889/prints-per-line-contribution-per-author-for-a-git-repository
-git ls-files $1 | xargs -n1 git blame --line-porcelain | sed -n 's/^author //p' | LC_ALL='C' sort -f | uniq -ic | sort -nr
+git ls-files $1 | xargs -n1 git blame -w -C -M --line-porcelain | sed -n 's/^author //p' | LC_ALL='C' sort -f | uniq -ic | sort -nr


### PR DESCRIPTION
On [teachers-pet](https://github.com/education/teachers-pet):

```
# BEFORE
~/dev/teachers-pet $ git fault .
 926 Aidan Feldman
  56 Mike Helmick
  25 John Britton
   4 kelleydv
# AFTER
~/dev/teachers-pet $ git fault .
 499 Aidan Feldman
 463 Mike Helmick
  31 John Britton
  14 Matthew Hartman
   4 kelleydv
```

Much more accurate :+1: 

http://git-scm.com/docs/git-blame

/cc @mikehelmick
